### PR TITLE
add registry switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add image registry switch to automatically switch the used image registry based on the installation region
+
 ## [0.8.0] - 2022-09-21
 
 ### Changed

--- a/helm/linkerd2-multicluster-link-app/README.md
+++ b/helm/linkerd2-multicluster-link-app/README.md
@@ -21,7 +21,7 @@ Kubernetes: `>=1.17.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| controllerImage | string | `"quay.io/giantswarm/linkerd2-controller"` | Docker image for the Service mirror component (uses the Linkerd controller image) |
+| controllerImage | string | `"giantswarm/linkerd2-controller"` | Docker image for the Service mirror component (uses the Linkerd controller image) |
 | controllerImageVersion | string | `"stable-2.11.4"` | Tag for the Service Mirror container Docker image |
 | enableHeadlessServices | bool | `false` | Toggle support for mirroring headless services |
 | enablePSP | bool | `true` | Create RoleBindings to associate ServiceAccount of target cluster Service Mirror to the control plane PSP resource. This requires that `enabledPSP` is set to true on the extension and control plane install. Note PSP has been deprecated since k8s v1.21 |

--- a/helm/linkerd2-multicluster-link-app/templates/service-mirror.yaml
+++ b/helm/linkerd2-multicluster-link-app/templates/service-mirror.yaml
@@ -114,7 +114,7 @@ spec:
         {{- end }}
         - -enable-pprof={{.Values.enablePprof | default false}}
         - {{.Values.target.name | default .Values.clusterID}}
-        image: {{.Values.controllerImage}}:{{.Values.controllerImageVersion}}
+        image: "{{.Values.image.registry}}/{{.Values.controllerImage}}:{{.Values.controllerImageVersion}}"
         name: service-mirror
         securityContext:
           runAsUser: {{.Values.serviceMirrorUID}}

--- a/helm/linkerd2-multicluster-link-app/values.schema.json
+++ b/helm/linkerd2-multicluster-link-app/values.schema.json
@@ -27,6 +27,14 @@
                 }
             }
         },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string"
+                }
+            }
+        },
         "logLevel": {
             "type": "string"
         },

--- a/helm/linkerd2-multicluster-link-app/values.yaml
+++ b/helm/linkerd2-multicluster-link-app/values.yaml
@@ -1,6 +1,10 @@
+# -- Registry switch
+# Do not overwrite this as it is automatically set based on the installation region
+image:
+  registry: quay.io
 # -- Docker image for the Service mirror component (uses the Linkerd controller
 # image)
-controllerImage: quay.io/giantswarm/linkerd2-controller
+controllerImage: giantswarm/linkerd2-controller
 # -- Tag for the Service Mirror container Docker image
 controllerImageVersion: stable-2.11.4
 # -- Toggle support for mirroring headless services


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- adds image registry switch to automatically switch the used image registry based on the installation region

### Testing

Description on how linkerd2-multicluster-link-app can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for linkerd2-multicluster-link-app installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
