### PR TITLE
Update icon url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update icon URL in `Chart.yaml` to self-hosted
+
 ## [0.9.0] - 2022-11-07
 
 ### Changed

--- a/helm/linkerd-multicluster-link/Chart.yaml
+++ b/helm/linkerd-multicluster-link/Chart.yaml
@@ -13,7 +13,7 @@ kubeVersion: ">=1.21.0-0"
 dependencies:
   - name: partials
     version: 0.1.0
-icon: https://linkerd.io/images/logo-only-200h.png
+icon: https://s.giantswarm.io/app-icons/linkerd2/2/logo_dark.svg
 name: "linkerd-multicluster-link"
 version: 0.9.0
 restrictions:


### PR DESCRIPTION
This PR:

- changes the icon URL in `Chart.yaml` to a self-hosted icon

Towards https://github.com/giantswarm/roadmap/issues/1248

### Checklist

- [x] Update changelog in CHANGELOG.md.